### PR TITLE
Update transaction.py for marshmallow-3

### DIFF
--- a/cashman/model/transaction.py
+++ b/cashman/model/transaction.py
@@ -16,6 +16,6 @@ class Transaction(object):
 
 class TransactionSchema(Schema):
     description = fields.Str()
-    amount = fields.Number()
+    amount = fields.Float()
     created_at = fields.Date()
     type = fields.Str()


### PR DESCRIPTION
Marshmallow v3 update forces Number to be an Integer or a Float (can no longer use 'Number')

Error message: 
AttributeError: 'Number' object has no attribute 'num_type'